### PR TITLE
Bug Fix: query::rows::get(int, std::string) will return an empty string ...

### DIFF
--- a/src/sqlite3pp.cpp
+++ b/src/sqlite3pp.cpp
@@ -414,7 +414,8 @@ namespace sqlite3pp
 
   std::string query::rows::get(int idx, std::string) const
   {
-    return get(idx, (char const*)0);
+    auto result = get(idx, (char const*)0);
+    return result ? result : std::string();
   }
 
   void const* query::rows::get(int idx, void const*) const


### PR DESCRIPTION
...when the data of column is empty.