### PR TITLE
More Strict Warnings Cleanup

### DIFF
--- a/test/testaggregate.cpp
+++ b/test/testaggregate.cpp
@@ -5,12 +5,18 @@
 
 using namespace std;
 
+void step0(sqlite3pp::ext::context& c);
+void finalize0(sqlite3pp::ext::context& c);
+void step1(sqlite3pp::ext::context& c);
+void finalize1(sqlite3pp::ext::context& c);
+
 void step0(sqlite3pp::ext::context& c)
 {
   int* sum = (int*) c.aggregate_data(sizeof(int));
 
   *sum += c.get<int>(0);
 }
+
 void finalize0(sqlite3pp::ext::context& c)
 {
   int* sum = (int*) c.aggregate_data(sizeof(int));
@@ -27,6 +33,7 @@ void step1(sqlite3pp::ext::context& c)
 
   *sum += c.get<string>(0);
 }
+
 void finalize1(sqlite3pp::ext::context& c)
 {
   string* sum = (string*) c.aggregate_data(sizeof(string));

--- a/test/testcallback.cpp
+++ b/test/testcallback.cpp
@@ -6,6 +6,8 @@
 using namespace std;
 using namespace std::placeholders;
 
+int handle_authorize(int evcode, char const* p1, char const* p2, char const* dbname, char const* tvname);
+
 struct handler
 {
   handler() : cnt_(0) {}

--- a/test/testfunction.cpp
+++ b/test/testfunction.cpp
@@ -5,6 +5,13 @@
 
 using namespace std;
 
+int test0();
+void test1(sqlite3pp::ext::context& ctx);
+void test2(sqlite3pp::ext::context& ctx);
+void test3(sqlite3pp::ext::context& ctx);
+std::string test5(std::string const& value);
+std::string test6(std::string const& s1, std::string const& s2, std::string const& s3);
+
 int test0()
 {
   return 100;


### PR DESCRIPTION
With warnings/errors at the highest levels, functions are expected to be declared before they are defined in main translation unit. Adding declarations to the top of the sources for each free function. 