### PR TITLE
Eliminate Unused Parameter Warnings

### DIFF
--- a/src/sqlite3pp.cpp
+++ b/src/sqlite3pp.cpp
@@ -422,7 +422,7 @@ namespace sqlite3pp
     return sqlite3_column_blob(stmt_, idx);
   }
 
-  null_type query::rows::get(int idx, null_type) const
+  null_type query::rows::get(int /* idx */, null_type) const
   {
     return ignore;
   }

--- a/src/sqlite3pp.cpp
+++ b/src/sqlite3pp.cpp
@@ -422,7 +422,7 @@ namespace sqlite3pp
     return sqlite3_column_blob(stmt_, idx);
   }
 
-  null_type query::rows::get(int /* idx */, null_type) const
+  null_type query::rows::get(int /*idx*/, null_type) const
   {
     return ignore;
   }

--- a/src/sqlite3ppext.h
+++ b/src/sqlite3ppext.h
@@ -123,7 +123,7 @@ namespace sqlite3pp
         auto h = std::make_tuple(c.context::get<H>(index));
         return std::tuple_cat(h, to_tuple_impl(++index, c, std::tuple<Ts...>()));
       }
-      static inline std::tuple<> to_tuple_impl(int index, const context& c, std::tuple<>&&)
+      static inline std::tuple<> to_tuple_impl(int /* index */, const context& /* c */, std::tuple<>&&)
       {
         return std::tuple<>();
       }

--- a/src/sqlite3ppext.h
+++ b/src/sqlite3ppext.h
@@ -123,7 +123,7 @@ namespace sqlite3pp
         auto h = std::make_tuple(c.context::get<H>(index));
         return std::tuple_cat(h, to_tuple_impl(++index, c, std::tuple<Ts...>()));
       }
-      static inline std::tuple<> to_tuple_impl(int /* index */, const context& /* c */, std::tuple<>&&)
+      static inline std::tuple<> to_tuple_impl(int /*index*/, const context& /*c*/, std::tuple<>&&)
       {
         return std::tuple<>();
       }

--- a/test/testaggregate.cpp
+++ b/test/testaggregate.cpp
@@ -83,7 +83,7 @@ struct plussum
   int n_;
 };
 
-int main(int argc, char* argv[])
+int main()
 {
   try {
     sqlite3pp::database db("foods.db");

--- a/test/testattach.cpp
+++ b/test/testattach.cpp
@@ -3,7 +3,7 @@
 
 using namespace std;
 
-int main(int argc, char* argv[])
+int main()
 {
   try {
     sqlite3pp::database db("foods.db");

--- a/test/testcallback.cpp
+++ b/test/testcallback.cpp
@@ -16,7 +16,7 @@ struct handler
   int cnt_;
 };
 
-int handle_authorize(int evcode, char const* /* p1 */, char const* /* p2 */, char const* /* dbname */, char const* /* tvname */) {
+int handle_authorize(int evcode, char const* /*p1*/, char const* /*p2*/, char const* /*dbname*/, char const* /*tvname*/) {
   cout << "handle_authorize(" << evcode << ")" << endl;
   return 0;
 }

--- a/test/testcallback.cpp
+++ b/test/testcallback.cpp
@@ -16,7 +16,7 @@ struct handler
   int cnt_;
 };
 
-int handle_authorize(int evcode, char const* p1, char const* p2, char const* dbname, char const* tvname) {
+int handle_authorize(int evcode, char const* /* p1 */, char const* /* p2 */, char const* /* dbname */, char const* /* tvname */) {
   cout << "handle_authorize(" << evcode << ")" << endl;
   return 0;
 }
@@ -28,7 +28,7 @@ struct rollback_handler
   }
 };
 
-int main(int argc, char* argv[])
+int main()
 {
   try {
     sqlite3pp::database db("test.db");

--- a/test/testdisconnect.cpp
+++ b/test/testdisconnect.cpp
@@ -3,7 +3,7 @@
 
 using namespace std;
 
-int main(int argc, char* argv[])
+int main()
 {
   try {
     sqlite3pp::database db("test.db");

--- a/test/testfunction.cpp
+++ b/test/testfunction.cpp
@@ -36,7 +36,7 @@ std::string test6(std::string const& s1, std::string const& s2, std::string cons
   return s1 + s2 + s3;
 }
 
-int main(int argc, char* argv[])
+int main()
 {
   try {
     sqlite3pp::database db("test.db");

--- a/test/testinsert.cpp
+++ b/test/testinsert.cpp
@@ -3,7 +3,7 @@
 
 using namespace std;
 
-int main(int argc, char* argv[])
+int main()
 {
   try {
     sqlite3pp::database db("test.db");

--- a/test/testinsertall.cpp
+++ b/test/testinsertall.cpp
@@ -3,7 +3,7 @@
 
 using namespace std;
 
-int main(int argc, char* argv[])
+int main()
 {
   try {
     sqlite3pp::database db("test.db");

--- a/test/testselect.cpp
+++ b/test/testselect.cpp
@@ -4,7 +4,7 @@
 
 using namespace std;
 
-int main(int argc, char* argv[])
+int main()
 {
   try {
     sqlite3pp::database db("test.db");


### PR DESCRIPTION
With warnings/errors at maximum level, unused parameters emit warnings. This branch eliminates these warnings by commenting out the parameter names. 