### PR TITLE
Eliminate conversion error

### DIFF
--- a/src/sqlite3pp.cpp
+++ b/src/sqlite3pp.cpp
@@ -26,6 +26,7 @@
 #include <memory>
 
 #include "sqlite3pp.h"
+#include "./trim_strlen.h"
 
 namespace sqlite3pp
 {
@@ -216,7 +217,7 @@ namespace sqlite3pp
 
   int statement::prepare_impl(char const* stmt)
   {
-    return sqlite3_prepare(db_.db_, stmt, std::strlen(stmt), &stmt_, &tail_);
+    return sqlite3_prepare(db_.db_, stmt, details::trim_strlen(std::strlen(stmt)), &stmt_, &tail_);
   }
 
   int statement::finish()
@@ -263,7 +264,7 @@ namespace sqlite3pp
 
   int statement::bind(int idx, char const* value, bool fstatic)
   {
-    return sqlite3_bind_text(stmt_, idx, value, std::strlen(value), fstatic ? SQLITE_STATIC : SQLITE_TRANSIENT);
+    return sqlite3_bind_text(stmt_, idx, value, details::trim_strlen(std::strlen(value)), fstatic ? SQLITE_STATIC : SQLITE_TRANSIENT);
   }
 
   int statement::bind(int idx, void const* value, int n, bool fstatic)

--- a/src/sqlite3ppext.cpp
+++ b/src/sqlite3ppext.cpp
@@ -25,6 +25,7 @@
 #include <cstring>
 
 #include "sqlite3ppext.h"
+#include "./trim_strlen.h"
 
 namespace sqlite3pp
 {
@@ -134,7 +135,7 @@ namespace sqlite3pp
 
     void context::result(char const* value, bool fstatic)
     {
-      sqlite3_result_text(ctx_, value, std::strlen(value), fstatic ? SQLITE_STATIC : SQLITE_TRANSIENT);
+      sqlite3_result_text(ctx_, value, details::trim_strlen(std::strlen(value)), fstatic ? SQLITE_STATIC : SQLITE_TRANSIENT);
     }
 
     void context::result(void const* value, int n, bool fstatic)
@@ -159,7 +160,7 @@ namespace sqlite3pp
 
     void context::result_error(char const* msg)
     {
-      sqlite3_result_error(ctx_, msg, std::strlen(msg));
+      sqlite3_result_error(ctx_, msg, details::trim_strlen(std::strlen(msg)));
     }
 
     void* context::aggregate_data(int size)

--- a/src/trim_strlen.cpp
+++ b/src/trim_strlen.cpp
@@ -1,0 +1,13 @@
+#include "./trim_strlen.h"
+#include <limits>
+
+namespace sqlite3pp { namespace details {
+
+    int trim_strlen(const std::size_t len)
+    {
+        return
+            len >= std::numeric_limits<int>::max()
+                ?  std::numeric_limits<int>::max()
+                :  static_cast<int>(len);
+    }
+}}

--- a/src/trim_strlen.h
+++ b/src/trim_strlen.h
@@ -1,0 +1,8 @@
+#pragma once 
+#include <cstddef> 
+
+namespace sqlite3pp { namespace details {
+
+    // if our string is longer than what an int can hold, truncate it.
+    int trim_strlen(const std::size_t len);
+}}


### PR DESCRIPTION
sqlite3pp was converting a std::size_t to an int, this generates a warning when warnings are turned all the way up on 64-bit platforms. It can also be considered a little dangerous to do this conversion without ensuring the value will fit in an 'int'.

To be a little more correct/robust, I added a function details::trim_strlen that ensures the value will fit into an int or it truncates the value to fit. Using this function eliminates the warning on 64-bit platforms. 