### PR TITLE
Move operators for sqlite3pp::database

### DIFF
--- a/src/sqlite3pp.cpp
+++ b/src/sqlite3pp.cpp
@@ -75,13 +75,12 @@ namespace sqlite3pp
     }
   }
 
-  database::database(database&& db)
-    : db_(std::move(db.db_))
-    , bh_(std::move(db.bh_))
-    , ch_(std::move(db.ch_))
-    , rh_(std::move(db.rh_))
-    , uh_(std::move(db.uh_))
-    , ah_(std::move(db.ah_))
+  database::database(database&& db) : db_(std::move(db.db_)),
+  bh_(std::move(db.bh_)),
+  ch_(std::move(db.ch_)),
+  rh_(std::move(db.rh_)),
+  uh_(std::move(db.uh_)),
+  ah_(std::move(db.ah_))
   {
     db.db_ = nullptr;
   }

--- a/src/sqlite3pp.cpp
+++ b/src/sqlite3pp.cpp
@@ -76,11 +76,11 @@ namespace sqlite3pp
   }
 
   database::database(database&& db) : db_(std::move(db.db_)),
-  bh_(std::move(db.bh_)),
-  ch_(std::move(db.ch_)),
-  rh_(std::move(db.rh_)),
-  uh_(std::move(db.uh_)),
-  ah_(std::move(db.ah_))
+    bh_(std::move(db.bh_)),
+    ch_(std::move(db.ch_)),
+    rh_(std::move(db.rh_)),
+    uh_(std::move(db.uh_)),
+    ah_(std::move(db.ah_))
   {
     db.db_ = nullptr;
   }

--- a/src/sqlite3pp.cpp
+++ b/src/sqlite3pp.cpp
@@ -75,6 +75,31 @@ namespace sqlite3pp
     }
   }
 
+  database::database(database&& db)
+    : db_(std::move(db.db_))
+    , bh_(std::move(db.bh_))
+    , ch_(std::move(db.ch_))
+    , rh_(std::move(db.rh_))
+    , uh_(std::move(db.uh_))
+    , ah_(std::move(db.ah_))
+  {
+    db.db_ = nullptr;
+  }
+
+  database& database::operator=(database&& db)
+  {
+    db_ = std::move(db.db_);
+    db.db_ = nullptr;
+
+    bh_ = std::move(db.bh_);
+    ch_ = std::move(db.ch_);
+    rh_ = std::move(db.rh_);
+    uh_ = std::move(db.uh_);
+    ah_ = std::move(db.ah_);
+
+    return *this;
+  }
+
   database::~database()
   {
     disconnect();

--- a/src/sqlite3pp.h
+++ b/src/sqlite3pp.h
@@ -54,6 +54,9 @@ namespace sqlite3pp
     noncopyable() = default;
     ~noncopyable() = default;
 
+    noncopyable(noncopyable&&) = default;
+    noncopyable& operator=(noncopyable&&) = default;
+
     noncopyable(noncopyable const&) = delete;
     noncopyable& operator=(noncopyable const&) = delete;
   };
@@ -73,6 +76,10 @@ namespace sqlite3pp
     using authorize_handler = std::function<int (int, char const*, char const*, char const*, char const*)>;
 
     explicit database(char const* dbname = nullptr, int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, const char* vfs = nullptr);
+
+    database(database&& db);
+    database& operator=(database&& db);
+
     ~database();
 
     int connect(char const* dbname, int flags, const char* vfs = nullptr);


### PR DESCRIPTION
Adding move constructor and move assignment operator for sqlite3pp::database. This allows creation of DB in a functional programming style (where actual construction will happen in a factory method). 