### PR TITLE
Replace long long int with sqlite3_int64

### DIFF
--- a/boost_src/sqlite3pp.cpp
+++ b/boost_src/sqlite3pp.cpp
@@ -50,7 +50,7 @@ namespace sqlite3pp
       (*h)();
     }
 
-    void update_hook_impl(void* p, int opcode, char const* dbname, char const* tablename, long long int rowid)
+    void update_hook_impl(void* p, int opcode, char const* dbname, char const* tablename, sqlite3_int64 rowid)
     {
       database::update_handler* h = static_cast<database::update_handler*>(p);
       (*h)(opcode, dbname, tablename, rowid);
@@ -145,7 +145,7 @@ namespace sqlite3pp
     sqlite3_set_authorizer(db_, ah_ ? authorizer_impl : 0, &ah_);
   }
 
-  long long int database::last_insert_rowid() const
+  sqlite3_int64 database::last_insert_rowid() const
   {
     return sqlite3_last_insert_rowid(db_);
   }
@@ -248,7 +248,7 @@ namespace sqlite3pp
     return sqlite3_bind_double(stmt_, idx, value);
   }
 
-  int statement::bind(int idx, long long int value)
+  int statement::bind(int idx, sqlite3_int64 value)
   {
     return sqlite3_bind_int64(stmt_, idx, value);
   }
@@ -285,7 +285,7 @@ namespace sqlite3pp
     return bind(idx, value);
   }
 
-  int statement::bind(char const* name, long long int value)
+  int statement::bind(char const* name, sqlite3_int64 value)
   {
     int idx = sqlite3_bind_parameter_index(stmt_, name);
     return bind(idx, value);
@@ -394,7 +394,7 @@ namespace sqlite3pp
     return sqlite3_column_double(stmt_, idx);
   }
 
-  long long int query::rows::get(int idx, long long int) const
+  sqlite3_int64 query::rows::get(int idx, sqlite3_int64) const
   {
     return sqlite3_column_int64(stmt_, idx);
   }

--- a/boost_src/sqlite3pp.h
+++ b/boost_src/sqlite3pp.h
@@ -55,7 +55,7 @@ namespace sqlite3pp
     typedef boost::function<int (int)> busy_handler;
     typedef boost::function<int ()> commit_handler;
     typedef boost::function<void ()> rollback_handler;
-    typedef boost::function<void (int, char const*, char const*, long long int)> update_handler;
+    typedef boost::function<void (int, char const*, char const*, sqlite3_int64)> update_handler;
     typedef boost::function<int (int, char const*, char const*, char const*, char const*)> authorize_handler;
 
     explicit database(char const* dbname = 0);
@@ -68,7 +68,7 @@ namespace sqlite3pp
     int attach(char const* dbname, char const* name);
     int detach(char const* name);
 
-    long long int last_insert_rowid() const;
+    sqlite3_int64 last_insert_rowid() const;
 
     int error_code() const;
     char const* error_msg() const;
@@ -109,7 +109,7 @@ namespace sqlite3pp
 
     int bind(int idx, int value);
     int bind(int idx, double value);
-    int bind(int idx, long long int value);
+    int bind(int idx, sqlite3_int64 value);
     int bind(int idx, char const* value, bool fstatic = true);
     int bind(int idx, void const* value, int n, bool fstatic = true);
     int bind(int idx);
@@ -117,7 +117,7 @@ namespace sqlite3pp
 
     int bind(char const* name, int value);
     int bind(char const* name, double value);
-    int bind(char const* name, long long int value);
+    int bind(char const* name, sqlite3_int64 value);
     int bind(char const* name, char const* value, bool fstatic = true);
     int bind(char const* name, void const* value, int n, bool fstatic = true);
     int bind(char const* name);
@@ -249,7 +249,7 @@ namespace sqlite3pp
      private:
       int get(int idx, int) const;
       double get(int idx, double) const;
-      long long int get(int idx, long long int) const;
+      sqlite3_int64 get(int idx, sqlite3_int64) const;
       char const* get(int idx, char const*) const;
       std::string get(int idx, std::string) const;
       void const* get(int idx, void const*) const;

--- a/boost_src/sqlite3ppext.cpp
+++ b/boost_src/sqlite3ppext.cpp
@@ -88,7 +88,7 @@ namespace sqlite3pp
       return sqlite3_value_double(values_[idx]);
     }
 
-    long long int context::get(int idx, long long int) const
+    sqlite3_int64 context::get(int idx, sqlite3_int64) const
     {
       return sqlite3_value_int64(values_[idx]);
     }
@@ -120,7 +120,7 @@ namespace sqlite3pp
       sqlite3_result_double(ctx_, value);
     }
 
-    void context::result(long long int value)
+    void context::result(sqlite3_int64 value)
     {
       sqlite3_result_int64(ctx_, value);
     }

--- a/boost_src/sqlite3ppext.h
+++ b/boost_src/sqlite3ppext.h
@@ -50,7 +50,7 @@ namespace sqlite3pp
 
       void result(int value);
       void result(double value);
-      void result(long long int value);
+      void result(sqlite3_int64 value);
       void result(std::string const& value);
       void result(char const* value, bool fstatic = true);
       void result(void const* value, int n, bool fstatic = true);
@@ -65,7 +65,7 @@ namespace sqlite3pp
      private:
       int get(int idx, int) const;
       double get(int idx, double) const;
-      long long int get(int idx, long long int) const;
+      sqlite3_int64 get(int idx, sqlite3_int64) const;
       char const* get(int idx, char const*) const;
       std::string get(int idx, std::string) const;
       void const* get(int idx, void const*) const;

--- a/headeronly_src/sqlite3pp.h
+++ b/headeronly_src/sqlite3pp.h
@@ -76,7 +76,7 @@ namespace sqlite3pp
     using busy_handler = std::function<int (int)>;
     using commit_handler = std::function<int ()>;
     using rollback_handler = std::function<void ()>;
-    using update_handler = std::function<void (int, char const*, char const*, long long int)>;
+    using update_handler = std::function<void (int, char const*, char const*, sqlite3_int64)>;
     using authorize_handler = std::function<int (int, char const*, char const*, char const*, char const*)>;
 
     explicit database(char const* dbname = nullptr, int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, const char* vfs = nullptr);
@@ -92,7 +92,7 @@ namespace sqlite3pp
     int attach(char const* dbname, char const* name);
     int detach(char const* name);
 
-    long long int last_insert_rowid() const;
+    sqlite3_int64 last_insert_rowid() const;
 
     int enable_foreign_keys(bool enable = true);
     int enable_triggers(bool enable = true);
@@ -139,7 +139,7 @@ namespace sqlite3pp
 
     int bind(int idx, int value);
     int bind(int idx, double value);
-    int bind(int idx, long long int value);
+    int bind(int idx, sqlite3_int64 value);
     int bind(int idx, char const* value, copy_semantic fcopy);
     int bind(int idx, void const* value, int n, copy_semantic fcopy);
     int bind(int idx, std::string const& value, copy_semantic fcopy);
@@ -148,7 +148,7 @@ namespace sqlite3pp
 
     int bind(char const* name, int value);
     int bind(char const* name, double value);
-    int bind(char const* name, long long int value);
+    int bind(char const* name, sqlite3_int64 value);
     int bind(char const* name, char const* value, copy_semantic fcopy);
     int bind(char const* name, void const* value, int n, copy_semantic fcopy);
     int bind(char const* name, std::string const& value, copy_semantic fcopy);
@@ -262,7 +262,7 @@ namespace sqlite3pp
      private:
       int get(int idx, int) const;
       double get(int idx, double) const;
-      long long int get(int idx, long long int) const;
+      sqlite3_int64 get(int idx, sqlite3_int64) const;
       char const* get(int idx, char const*) const;
       std::string get(int idx, std::string) const;
       void const* get(int idx, void const*) const;

--- a/headeronly_src/sqlite3pp.ipp
+++ b/headeronly_src/sqlite3pp.ipp
@@ -50,7 +50,7 @@ namespace sqlite3pp
       (*h)();
     }
 
-    void update_hook_impl(void* p, int opcode, char const* dbname, char const* tablename, long long int rowid)
+    void update_hook_impl(void* p, int opcode, char const* dbname, char const* tablename, sqlite3_int64 rowid)
     {
       auto h = static_cast<database::update_handler*>(p);
       (*h)(opcode, dbname, tablename, rowid);
@@ -162,7 +162,7 @@ namespace sqlite3pp
     sqlite3_set_authorizer(db_, ah_ ? authorizer_impl : 0, &ah_);
   }
 
-  inline long long int database::last_insert_rowid() const
+  inline sqlite3_int64 database::last_insert_rowid() const
   {
     return sqlite3_last_insert_rowid(db_);
   }
@@ -280,7 +280,7 @@ namespace sqlite3pp
     return sqlite3_bind_double(stmt_, idx, value);
   }
 
-  inline int statement::bind(int idx, long long int value)
+  inline int statement::bind(int idx, sqlite3_int64 value)
   {
     return sqlite3_bind_int64(stmt_, idx, value);
   }
@@ -322,7 +322,7 @@ namespace sqlite3pp
     return bind(idx, value);
   }
 
-  inline int statement::bind(char const* name, long long int value)
+  inline int statement::bind(char const* name, sqlite3_int64 value)
   {
     auto idx = sqlite3_bind_parameter_index(stmt_, name);
     return bind(idx, value);
@@ -437,7 +437,7 @@ namespace sqlite3pp
     return sqlite3_column_double(stmt_, idx);
   }
 
-  inline long long int query::rows::get(int idx, long long int) const
+  inline sqlite3_int64 query::rows::get(int idx, sqlite3_int64) const
   {
     return sqlite3_column_int64(stmt_, idx);
   }
@@ -461,7 +461,7 @@ namespace sqlite3pp
   {
     return ignore;
   }
-  
+
   inline query::rows::getstream query::rows::getter(int idx)
   {
     return getstream(this, idx);

--- a/headeronly_src/sqlite3ppext.h
+++ b/headeronly_src/sqlite3ppext.h
@@ -92,7 +92,7 @@ namespace sqlite3pp
 
       void result(int value);
       void result(double value);
-      void result(long long int value);
+      void result(sqlite3_int64 value);
       void result(std::string const& value);
       void result(char const* value, bool fcopy);
       void result(void const* value, int n, bool fcopy);
@@ -112,7 +112,7 @@ namespace sqlite3pp
      private:
       int get(int idx, int) const;
       double get(int idx, double) const;
-      long long int get(int idx, long long int) const;
+      sqlite3_int64 get(int idx, sqlite3_int64) const;
       char const* get(int idx, char const*) const;
       std::string get(int idx, std::string) const;
       void const* get(int idx, void const*) const;

--- a/headeronly_src/sqlite3ppext.ipp
+++ b/headeronly_src/sqlite3ppext.ipp
@@ -88,7 +88,7 @@ namespace sqlite3pp
       return sqlite3_value_double(values_[idx]);
     }
 
-    inline long long int context::get(int idx, long long int) const
+    inline sqlite3_int64 context::get(int idx, sqlite3_int64) const
     {
       return sqlite3_value_int64(values_[idx]);
     }
@@ -120,7 +120,7 @@ namespace sqlite3pp
       sqlite3_result_double(ctx_, value);
     }
 
-    inline void context::result(long long int value)
+    inline void context::result(sqlite3_int64 value)
     {
       sqlite3_result_int64(ctx_, value);
     }

--- a/src/sqlite3pp.cpp
+++ b/src/sqlite3pp.cpp
@@ -52,7 +52,7 @@ namespace sqlite3pp
       (*h)();
     }
 
-    void update_hook_impl(void* p, int opcode, char const* dbname, char const* tablename, long long int rowid)
+    void update_hook_impl(void* p, int opcode, char const* dbname, char const* tablename, sqlite3_int64 rowid)
     {
       auto h = static_cast<database::update_handler*>(p);
       (*h)(opcode, dbname, tablename, rowid);
@@ -164,7 +164,7 @@ namespace sqlite3pp
     sqlite3_set_authorizer(db_, ah_ ? authorizer_impl : 0, &ah_);
   }
 
-  long long int database::last_insert_rowid() const
+  sqlite3_int64 database::last_insert_rowid() const
   {
     return sqlite3_last_insert_rowid(db_);
   }
@@ -282,7 +282,7 @@ namespace sqlite3pp
     return sqlite3_bind_double(stmt_, idx, value);
   }
 
-  int statement::bind(int idx, long long int value)
+  int statement::bind(int idx, sqlite3_int64 value)
   {
     return sqlite3_bind_int64(stmt_, idx, value);
   }
@@ -324,7 +324,7 @@ namespace sqlite3pp
     return bind(idx, value);
   }
 
-  int statement::bind(char const* name, long long int value)
+  int statement::bind(char const* name, sqlite3_int64 value)
   {
     auto idx = sqlite3_bind_parameter_index(stmt_, name);
     return bind(idx, value);
@@ -439,7 +439,7 @@ namespace sqlite3pp
     return sqlite3_column_double(stmt_, idx);
   }
 
-  long long int query::rows::get(int idx, long long int) const
+  sqlite3_int64 query::rows::get(int idx, sqlite3_int64) const
   {
     return sqlite3_column_int64(stmt_, idx);
   }

--- a/src/sqlite3pp.h
+++ b/src/sqlite3pp.h
@@ -77,7 +77,7 @@ namespace sqlite3pp
     using busy_handler = std::function<int (int)>;
     using commit_handler = std::function<int ()>;
     using rollback_handler = std::function<void ()>;
-    using update_handler = std::function<void (int, char const*, char const*, long long int)>;
+    using update_handler = std::function<void (int, char const*, char const*, sqlite3_int64)>;
     using authorize_handler = std::function<int (int, char const*, char const*, char const*, char const*)>;
 
     explicit database(char const* dbname = nullptr, int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, const char* vfs = nullptr);
@@ -93,7 +93,7 @@ namespace sqlite3pp
     int attach(char const* dbname, char const* name);
     int detach(char const* name);
 
-    long long int last_insert_rowid() const;
+    sqlite3_int64 last_insert_rowid() const;
 
     int enable_foreign_keys(bool enable = true);
     int enable_triggers(bool enable = true);
@@ -140,7 +140,7 @@ namespace sqlite3pp
 
     int bind(int idx, int value);
     int bind(int idx, double value);
-    int bind(int idx, long long int value);
+    int bind(int idx, sqlite3_int64 value);
     int bind(int idx, char const* value, copy_semantic fcopy);
     int bind(int idx, void const* value, int n, copy_semantic fcopy);
     int bind(int idx, std::string const& value, copy_semantic fcopy);
@@ -149,7 +149,7 @@ namespace sqlite3pp
 
     int bind(char const* name, int value);
     int bind(char const* name, double value);
-    int bind(char const* name, long long int value);
+    int bind(char const* name, sqlite3_int64 value);
     int bind(char const* name, char const* value, copy_semantic fcopy);
     int bind(char const* name, void const* value, int n, copy_semantic fcopy);
     int bind(char const* name, std::string const& value, copy_semantic fcopy);
@@ -263,7 +263,7 @@ namespace sqlite3pp
      private:
       int get(int idx, int) const;
       double get(int idx, double) const;
-      long long int get(int idx, long long int) const;
+      sqlite3_int64 get(int idx, sqlite3_int64) const;
       char const* get(int idx, char const*) const;
       std::string get(int idx, std::string) const;
       void const* get(int idx, void const*) const;

--- a/src/sqlite3ppext.cpp
+++ b/src/sqlite3ppext.cpp
@@ -90,7 +90,7 @@ namespace sqlite3pp
       return sqlite3_value_double(values_[idx]);
     }
 
-    long long int context::get(int idx, long long int) const
+    sqlite3_int64 context::get(int idx, sqlite3_int64) const
     {
       return sqlite3_value_int64(values_[idx]);
     }
@@ -122,7 +122,7 @@ namespace sqlite3pp
       sqlite3_result_double(ctx_, value);
     }
 
-    void context::result(long long int value)
+    void context::result(sqlite3_int64 value)
     {
       sqlite3_result_int64(ctx_, value);
     }

--- a/src/sqlite3ppext.h
+++ b/src/sqlite3ppext.h
@@ -92,7 +92,7 @@ namespace sqlite3pp
 
       void result(int value);
       void result(double value);
-      void result(long long int value);
+      void result(sqlite3_int64 value);
       void result(std::string const& value);
       void result(char const* value, bool fcopy);
       void result(void const* value, int n, bool fcopy);
@@ -112,7 +112,7 @@ namespace sqlite3pp
      private:
       int get(int idx, int) const;
       double get(int idx, double) const;
-      long long int get(int idx, long long int) const;
+      sqlite3_int64 get(int idx, sqlite3_int64) const;
       char const* get(int idx, char const*) const;
       std::string get(int idx, std::string) const;
       void const* get(int idx, void const*) const;

--- a/test/testcallback.cpp
+++ b/test/testcallback.cpp
@@ -10,7 +10,7 @@ struct handler
 {
   handler() : cnt_(0) {}
 
-  void handle_update(int opcode, char const* dbname, char const* tablename, long long int rowid) {
+  void handle_update(int opcode, char const* dbname, char const* tablename, sqlite3_int64 rowid) {
     cout << "handle_update(" << opcode << ", " << dbname << ", " << tablename << ", " << rowid << ") - " << cnt_++ << endl;
   }
   int cnt_;


### PR DESCRIPTION
So GCC users don't have to static_cast<long long int> on int64_t
by defining sqlite3_int64.