### PR TITLE
Add overloads for C++11 int64_t type

### DIFF
--- a/headeronly_src/sqlite3pp.h
+++ b/headeronly_src/sqlite3pp.h
@@ -30,6 +30,7 @@
 #define SQLITE3PP_VERSION_MINOR 0
 #define SQLITE3PP_VERSION_PATCH 0
 
+#include <cstdint>
 #include <functional>
 #include <iterator>
 #include <sqlite3.h>
@@ -145,6 +146,7 @@ namespace sqlite3pp
     int finish();
 
     int bind(int idx, int value);
+    int bind(int idx, int64_t value);
     int bind(int idx, double value);
     int bind(int idx, long long int value);
     int bind(int idx, char const* value, copy_semantic fcopy);
@@ -154,6 +156,7 @@ namespace sqlite3pp
     int bind(int idx, null_type);
 
     int bind(char const* name, int value);
+    int bind(char const* name, int64_t value);
     int bind(char const* name, double value);
     int bind(char const* name, long long int value);
     int bind(char const* name, char const* value, copy_semantic fcopy);
@@ -268,6 +271,7 @@ namespace sqlite3pp
 
      private:
       int get(int idx, int) const;
+      int get(int idx, int64_t) const;
       double get(int idx, double) const;
       long long int get(int idx, long long int) const;
       char const* get(int idx, char const*) const;

--- a/headeronly_src/sqlite3pp.ipp
+++ b/headeronly_src/sqlite3pp.ipp
@@ -307,6 +307,11 @@ namespace sqlite3pp
     return sqlite3_bind_int(stmt_, idx, value);
   }
 
+  inline int statement::bind(int idx, int64_t value)
+  {
+    return sqlite3_bind_int64(stmt_, idx, value);
+  }
+
   inline int statement::bind(int idx, double value)
   {
     return sqlite3_bind_double(stmt_, idx, value);
@@ -343,6 +348,12 @@ namespace sqlite3pp
   }
 
   inline int statement::bind(char const* name, int value)
+  {
+    auto idx = sqlite3_bind_parameter_index(stmt_, name);
+    return bind(idx, value);
+  }
+
+  inline int statement::bind(char const* name, int64_t value)
   {
     auto idx = sqlite3_bind_parameter_index(stmt_, name);
     return bind(idx, value);
@@ -464,6 +475,11 @@ namespace sqlite3pp
     return sqlite3_column_int(stmt_, idx);
   }
 
+  inline int query::rows::get(int idx, int64_t) const
+  {
+    return sqlite3_column_int64(stmt_, idx);
+  }
+
   inline double query::rows::get(int idx, double) const
   {
     return sqlite3_column_double(stmt_, idx);
@@ -493,7 +509,7 @@ namespace sqlite3pp
   {
     return ignore;
   }
-  
+
   inline query::rows::getstream query::rows::getter(int idx)
   {
     return getstream(this, idx);

--- a/src/sqlite3pp.cpp
+++ b/src/sqlite3pp.cpp
@@ -309,6 +309,11 @@ namespace sqlite3pp
     return sqlite3_bind_int(stmt_, idx, value);
   }
 
+  int statement::bind(int idx, int64_t value)
+  {
+    return sqlite3_bind_int64(stmt_, idx, value);
+  }
+
   int statement::bind(int idx, double value)
   {
     return sqlite3_bind_double(stmt_, idx, value);
@@ -345,6 +350,12 @@ namespace sqlite3pp
   }
 
   int statement::bind(char const* name, int value)
+  {
+    auto idx = sqlite3_bind_parameter_index(stmt_, name);
+    return bind(idx, value);
+  }
+
+  int statement::bind(char const* name, int64_t value)
   {
     auto idx = sqlite3_bind_parameter_index(stmt_, name);
     return bind(idx, value);
@@ -464,6 +475,11 @@ namespace sqlite3pp
   int query::rows::get(int idx, int) const
   {
     return sqlite3_column_int(stmt_, idx);
+  }
+
+  int query::rows::get(int idx, int64_t) const
+  {
+    return sqlite3_column_int64(stmt_, idx);
   }
 
   double query::rows::get(int idx, double) const

--- a/src/sqlite3pp.h
+++ b/src/sqlite3pp.h
@@ -30,6 +30,7 @@
 #define SQLITE3PP_VERSION_MINOR 0
 #define SQLITE3PP_VERSION_PATCH 0
 
+#include <cstdint>
 #include <functional>
 #include <iterator>
 #include <sqlite3.h>
@@ -146,6 +147,7 @@ namespace sqlite3pp
     int finish();
 
     int bind(int idx, int value);
+    int bind(int idx, int64_t value);
     int bind(int idx, double value);
     int bind(int idx, long long int value);
     int bind(int idx, char const* value, copy_semantic fcopy);
@@ -155,6 +157,7 @@ namespace sqlite3pp
     int bind(int idx, null_type);
 
     int bind(char const* name, int value);
+    int bind(char const* name, int64_t value);
     int bind(char const* name, double value);
     int bind(char const* name, long long int value);
     int bind(char const* name, char const* value, copy_semantic fcopy);
@@ -269,6 +272,7 @@ namespace sqlite3pp
 
      private:
       int get(int idx, int) const;
+      int get(int idx, int64_t) const;
       double get(int idx, double) const;
       long long int get(int idx, long long int) const;
       char const* get(int idx, char const*) const;


### PR DESCRIPTION
Adds convenience overloads for int64_t (standard c++ 64-bit integer type) to avoid extra casts to long long int.