### PR TITLE
added the possibility to assign an existent database handler

### DIFF
--- a/headeronly_src/sqlite3pp.h
+++ b/headeronly_src/sqlite3pp.h
@@ -28,11 +28,18 @@
 #define SQLITE3PP_VERSION "1.0.6"
 #define SQLITE3PP_VERSION_MAJOR 1
 #define SQLITE3PP_VERSION_MINOR 0
-#define SQLITE3PP_VERSION_PATCH 6
+#define SQLITE3PP_VERSION_PATCH 7
 
 #include <functional>
 #include <iterator>
+
+#ifdef COMPILE_SQLITE_EXTENSIONS_AS_LOADABLE_MODULE
+#include <sqlite3ext.h> /* Do not use <sqlite3.h>! */
+SQLITE_EXTENSION_INIT1
+#elif
 #include <sqlite3.h>
+#endif
+
 #include <stdexcept>
 #include <string>
 #include <tuple>
@@ -84,6 +91,7 @@ namespace sqlite3pp
 
     database(database&& db);
     database& operator=(database&& db);
+    database& operator=(sqlite3* _db);
 
     ~database();
 

--- a/headeronly_src/sqlite3pp.ipp
+++ b/headeronly_src/sqlite3pp.ipp
@@ -72,7 +72,7 @@ namespace sqlite3pp
         throw database_error("can't connect database");
     }
   }
-
+  
   inline database::database(database&& db) : db_(std::move(db.db_)),
     bh_(std::move(db.bh_)),
     ch_(std::move(db.ch_)),
@@ -93,6 +93,14 @@ namespace sqlite3pp
     rh_ = std::move(db.rh_);
     uh_ = std::move(db.uh_);
     ah_ = std::move(db.ah_);
+
+    return *this;
+  }
+
+  inline database& database::operator=(sqlite3* _db)
+  {
+    db_ = std::move(_db);
+    _db = nullptr;
 
     return *this;
   }


### PR DESCRIPTION
this is required by the loadext doc: see [there](https://sqlite.org/loadext.html)
When we load an extension, the database handler is already there before we can call any `sqlite3pp::database` constructor, hence the assignement overload with `sqlite3*`.

There is still some boilerplate to manage to make the extension loadable:
```C++
sqlite3pp::database dbe;

extern "C" {
int sqlite3_extension_init(/* <== Change this name, maybe */
                           sqlite3 *db,
                           char **pzErrMsg,
                           const sqlite3_api_routines *pApi)
{
    int rc = SQLITE_OK;
    SQLITE_EXTENSION_INIT2(pApi);
    dbe = db;
    sqlite3pp::ext::aggregate aggr(dbe);
    aggr.create<strcnt, string>("aggr2");
    aggr.create<plussum, int, int>("aggr3");
    return rc;
}
}
```