### PR TITLE
If function sqlite3_column_text return nullptr

### DIFF
--- a/src/sqlite3pp.cpp
+++ b/src/sqlite3pp.cpp
@@ -492,7 +492,12 @@ namespace sqlite3pp
 
   std::string query::rows::get(int idx, std::string) const
   {
-    return get(idx, (char const*)0);
+	const unsigned char *temp_p = sqlite3_column_text(stmt_, idx);
+	if (temp_p == nullptr)
+	{
+	  return std::string("");
+	}
+	return get(idx, (char const*)0);
   }
 
   void const* query::rows::get(int idx, void const*) const


### PR DESCRIPTION
If function sqlite3_column_text return nullptr
The std::string constructor func can't use nullptr
sqlite3_column_text 如果返回空指针
std::string直接GG