### PR TITLE
return empty string on null entry

### DIFF
--- a/headeronly_src/sqlite3pp.ipp
+++ b/headeronly_src/sqlite3pp.ipp
@@ -487,7 +487,8 @@ namespace sqlite3pp
 
   inline std::string query::rows::get(int idx, std::string) const
   {
-    return get(idx, (char const*)0);
+    char const* t = get(idx, (char const*)0);
+    return (t) ? t : std::string();
   }
 
   inline void const* query::rows::get(int idx, void const*) const

--- a/src/sqlite3pp.cpp
+++ b/src/sqlite3pp.cpp
@@ -492,7 +492,8 @@ namespace sqlite3pp
 
   std::string query::rows::get(int idx, std::string) const
   {
-    return get(idx, (char const*)0);
+    char const* t = get(idx, (char const*)0);
+    return (t) ? t : std::string();
   }
 
   void const* query::rows::get(int idx, void const*) const


### PR DESCRIPTION
This PR allows using std::string to retrieve null data values as well. If NULL, empty string is returned. I think, its more consistent interface and allows using the library in a simple manner. For those who want to distinguish empty string and NULL values, old approach through `const char*` should work.

Related: https://github.com/iwongu/sqlite3pp/issues/48 