### PR TITLE
changed query_iterator to work with C++17

### DIFF
--- a/headeronly_src/sqlite3pp.h
+++ b/headeronly_src/sqlite3pp.h
@@ -25,13 +25,12 @@
 #ifndef SQLITE3PP_H
 #define SQLITE3PP_H
 
-#define SQLITE3PP_VERSION "1.0.8"
+#define SQLITE3PP_VERSION "1.0.9"
 #define SQLITE3PP_VERSION_MAJOR 1
 #define SQLITE3PP_VERSION_MINOR 0
-#define SQLITE3PP_VERSION_PATCH 8
+#define SQLITE3PP_VERSION_PATCH 9
 
 #include <functional>
-#include <iterator>
 #include <stdexcept>
 #include <string>
 #include <tuple>

--- a/headeronly_src/sqlite3pp.h
+++ b/headeronly_src/sqlite3pp.h
@@ -294,9 +294,12 @@ namespace sqlite3pp
     };
 
     class query_iterator
-      : public std::iterator<std::input_iterator_tag, rows>
     {
      public:
+      using iterator_category = std::input_iterator_tag;
+      using value_type = rows;
+      using difference_type = void;
+
       query_iterator();
       explicit query_iterator(query* cmd);
 
@@ -311,7 +314,7 @@ namespace sqlite3pp
       query* cmd_;
       int rc_;
     };
-
+    
     explicit query(database& db, char const* stmt = nullptr);
 
     int column_count() const;

--- a/headeronly_src/sqlite3pp.h
+++ b/headeronly_src/sqlite3pp.h
@@ -297,7 +297,7 @@ namespace sqlite3pp
      public:
       using iterator_category = std::input_iterator_tag;
       using value_type = rows;
-      using difference_type = void;
+      using difference_type = rows&;
 
       query_iterator();
       explicit query_iterator(query* cmd);

--- a/headeronly_src/sqlite3pp.h
+++ b/headeronly_src/sqlite3pp.h
@@ -297,7 +297,9 @@ namespace sqlite3pp
      public:
       using iterator_category = std::input_iterator_tag;
       using value_type = rows;
-      using difference_type = rows&;
+      using difference_type = std::ptrdiff_t;
+      using pointer = rows*;
+      using reference = rows&;
 
       query_iterator();
       explicit query_iterator(query* cmd);

--- a/src/sqlite3pp.h
+++ b/src/sqlite3pp.h
@@ -298,7 +298,7 @@ namespace sqlite3pp
     public:
       using iterator_category = std::input_iterator_tag;
       using value_type = rows;
-      using difference_type = void;
+      using difference_type = rows&;
 
       query_iterator();
       explicit query_iterator(query* cmd);

--- a/src/sqlite3pp.h
+++ b/src/sqlite3pp.h
@@ -295,9 +295,12 @@ namespace sqlite3pp
     };
 
     class query_iterator
-      : public std::iterator<std::input_iterator_tag, rows>
     {
      public:
+      using iterator_category = std::input_iterator_tag;
+      using value_type = rows;
+      using difference_type = void;
+
       query_iterator();
       explicit query_iterator(query* cmd);
 
@@ -312,7 +315,7 @@ namespace sqlite3pp
       query* cmd_;
       int rc_;
     };
-
+    
     explicit query(database& db, char const* stmt = nullptr);
 
     int column_count() const;

--- a/src/sqlite3pp.h
+++ b/src/sqlite3pp.h
@@ -25,13 +25,12 @@
 #ifndef SQLITE3PP_H
 #define SQLITE3PP_H
 
-#define SQLITE3PP_VERSION "1.0.8"
+#define SQLITE3PP_VERSION "1.0.9"
 #define SQLITE3PP_VERSION_MAJOR 1
 #define SQLITE3PP_VERSION_MINOR 0
-#define SQLITE3PP_VERSION_PATCH 8
+#define SQLITE3PP_VERSION_PATCH 9
 
 #include <functional>
-#include <iterator>
 #include <stdexcept>
 #include <string>
 #include <tuple>
@@ -296,7 +295,7 @@ namespace sqlite3pp
 
     class query_iterator
     {
-     public:
+    public:
       using iterator_category = std::input_iterator_tag;
       using value_type = rows;
       using difference_type = void;
@@ -311,7 +310,7 @@ namespace sqlite3pp
 
       value_type operator*() const;
 
-     private:
+    private:
       query* cmd_;
       int rc_;
     };

--- a/src/sqlite3pp.h
+++ b/src/sqlite3pp.h
@@ -298,8 +298,10 @@ namespace sqlite3pp
     public:
       using iterator_category = std::input_iterator_tag;
       using value_type = rows;
-      using difference_type = rows&;
-
+      using difference_type = std::ptrdiff_t;
+      using pointer = rows*;
+      using reference = rows&;
+      
       query_iterator();
       explicit query_iterator(query* cmd);
 


### PR DESCRIPTION
In C++17 (and previous) versions it is not necessary to use std::iterator as base class when doing a new iterator.