### PR TITLE
Two patches: row.get<std::string> length fix and bind_blob(std::string)

### DIFF
--- a/src/sqlite3pp.cpp
+++ b/src/sqlite3pp.cpp
@@ -343,6 +343,11 @@ namespace sqlite3pp
     return sqlite3_bind_text(stmt_, idx, value.c_str(), value.size(), fcopy == copy ? SQLITE_TRANSIENT : SQLITE_STATIC );
   }
 
+  int statement::bind_blob(int idx, std::string const& value, copy_semantic fcopy)
+  {
+    return sqlite3_bind_blob(stmt_, idx, value.data(), value.size(), fcopy == copy ? SQLITE_TRANSIENT : SQLITE_STATIC );
+  }
+
   int statement::bind(int idx)
   {
     return sqlite3_bind_null(stmt_, idx);

--- a/src/sqlite3pp.cpp
+++ b/src/sqlite3pp.cpp
@@ -492,7 +492,7 @@ namespace sqlite3pp
 
   std::string query::rows::get(int idx, std::string) const
   {
-    return get(idx, (char const*)0);
+    return std::string(get(idx, (char const*)0), column_bytes(idx));
   }
 
   void const* query::rows::get(int idx, void const*) const

--- a/src/sqlite3pp.h
+++ b/src/sqlite3pp.h
@@ -165,6 +165,7 @@ namespace sqlite3pp
     int bind(int idx, char const* value, copy_semantic fcopy);
     int bind(int idx, void const* value, int n, copy_semantic fcopy);
     int bind(int idx, std::string const& value, copy_semantic fcopy);
+    int bind_blob(int idx, std::string const& value, copy_semantic fcopy);
     int bind(int idx);
     int bind(int idx, null_type);
 


### PR DESCRIPTION
row.get<std::string> was not working properly for strings containing a null character.