### PR TITLE
Modernize header-only implementation and resolve major issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-> #### ANNOUNCEMENTS
-> ##### Use files in `headeronly_src` directory. The files in `src` are exactly same but in the form of h/cpp files, which you need to compile and link with.
-> ##### `boost_src` is no longer maintained. Do not use unless you need to use pre-c++1x. It requires `boost` library.
+> #### PROJECT STATUS
+> ##### Only the `headeronly_src` directory is currently maintained and updated. Other directories such as `src`, `boost_src`, and the top-level `test` directory are obsolete and kept only for historical reference.
 
 sqlite3pp
 =========
@@ -13,19 +12,26 @@ With ext::function class, it's also easy to use the sqlite3's functions and aggr
 
 ## database
 ```cpp
+// Open a database file or :memory:
 sqlite3pp::database db("test.db");
+
+// Simple execution
 db.execute("INSERT INTO contacts (name, phone) VALUES ('Mike', '555-1234')");
+
+// Move semantics
+sqlite3pp::database db2 = std::move(db);
 ```
 
 ## command
 ```cpp
-sqlite3pp::command cmd(
-  db, "INSERT INTO contacts (name, phone) VALUES (?, ?)");
+// Using stream-like binder (automatically uses sqlite3pp::copy)
+sqlite3pp::command cmd(db, "INSERT INTO contacts (name, phone) VALUES (?, ?)");
 cmd.binder() << "Mike" << "555-1234";
 cmd.execute();
 ```
 
 ```cpp
+// Using positional binding with copy/nocopy semantics
 sqlite3pp::command cmd(db, "INSERT INTO contacts (name, phone) VALUES (?, ?)");
 cmd.bind(1, "Mike", sqlite3pp::nocopy);
 cmd.bind(2, "555-1234", sqlite3pp::nocopy);
@@ -33,22 +39,16 @@ cmd.execute();
 ```
 
 ```cpp
-sqlite3pp::command cmd(
-  db, "INSERT INTO contacts (name, phone) VALUES (?100, ?101)");
-cmd.bind(100, "Mike", sqlite3pp::nocopy);
-cmd.bind(101, "555-1234", sqlite3pp::nocopy);
-cmd.execute();
-```
-
-```cpp
-sqlite3pp::command cmd(
-  db, "INSERT INTO contacts (name, phone) VALUES (:user, :phone)");
+// Using named parameters
+sqlite3pp::command cmd(db, "INSERT INTO contacts (name, phone, age) VALUES (:user, :phone, :age)");
 cmd.bind(":user", "Mike", sqlite3pp::nocopy);
-cmd.bind(":phone", "555-1234", sqlite3pp::nocopy);
+cmd.bind(":phone", "555-1234", sqlite3pp::copy);
+cmd.bind(":age", 30);
 cmd.execute();
 ```
 
 ```cpp
+// Executing multiple statements (semicolon separated)
 sqlite3pp::command cmd(
   db,
   "INSERT INTO contacts (name, phone) VALUES (:user, '555-0000');"
@@ -63,13 +63,12 @@ cmd.execute_all();
 ```cpp
 sqlite3pp::transaction xct(db);
 {
-  sqlite3pp::command cmd(
-    db, "INSERT INTO contacts (name, phone) VALUES (:user, :phone)");
-  cmd.bind(":user", "Mike", sqlite3pp::nocopy);
-  cmd.bind(":phone", "555-1234", sqlite3pp::nocopy);
+  sqlite3pp::command cmd(db, "INSERT INTO contacts (name, phone) VALUES (?, ?)");
+  cmd.binder() << "Mike" << "555-1234";
   cmd.execute();
 }
-xct.rollback();
+// Automatically rollbacks if not committed
+xct.commit(); 
 ```
 
 ## query
@@ -77,42 +76,37 @@ xct.rollback();
 ```cpp
 sqlite3pp::query qry(db, "SELECT id, name, phone FROM contacts");
 
+// Accessing metadata
 for (int i = 0; i < qry.column_count(); ++i) {
   cout << qry.column_name(i) << "\t";
 }
 ```
 
 ```cpp
-for (sqlite3pp::query::iterator i = qry.begin(); i != qry.end(); ++i) {
-  for (int j = 0; j < qry.column_count(); ++j) {
-    cout << (*i).get<char const*>(j) << "\t";
-  }
-  cout << endl;
-}
-```
-
-```cpp
-for (sqlite3pp::query::iterator i = qry.begin(); i != qry.end(); ++i) {
+// Using range-based for loop
+for (auto row : qry) {
   int id;
-  char const* name, *phone;
-  std::tie(id, name, phone) =
-    (*i).get_columns<int, char const*, char const*>(0, 1, 2);
+  string name, phone;
+  row.getter() >> id >> name >> phone;
   cout << id << "\t" << name << "\t" << phone << endl;
 }
 ```
 
 ```cpp
-for (sqlite3pp::query::iterator i = qry.begin(); i != qry.end(); ++i) {
-  string name, phone;
-  (*i).getter() >> sqlite3pp::ignore >> name >> phone;
-  cout << "\t" << name << "\t" << phone << endl;
+// Using std::tie for multiple columns
+for (auto row : qry) {
+  int id;
+  char const *name, *phone;
+  std::tie(id, name, phone) = row.get_columns<int, char const*, char const*>(0, 1, 2);
+  cout << id << "\t" << name << "\t" << phone << endl;
 }
 ```
 
 ```cpp
-for (auto v : qry) {
+// Using sqlite3pp::ignore to skip columns
+for (auto row : qry) {
   string name, phone;
-  v.getter() >> sqlite3pp::ignore >> name >> phone;
+  row.getter() >> sqlite3pp::ignore >> name >> phone;
   cout << "\t" << name << "\t" << phone << endl;
 }
 ```
@@ -120,12 +114,10 @@ for (auto v : qry) {
 ## attach
 
 ```cpp
-sqlite3pp::database db("foods.db");
-db.attach("test.db", "test");
+sqlite3pp::database db("main.db");
+db.attach("other.db", "other");
 
-sqlite3pp::query qry(
-  db,
-  "SELECT epi.* FROM episodes epi, test.contacts con WHERE epi.id = con.id");
+sqlite3pp::query qry(db, "SELECT m.* FROM contacts m, other.contacts o WHERE m.id = o.id");
 ```
 
 ## backup
@@ -134,194 +126,67 @@ sqlite3pp::query qry(
 sqlite3pp::database db("test.db");
 sqlite3pp::database backupdb("backup.db");
 
+// Simple backup
 db.backup(backupdb);
+
+// Backup with progress handler
+db.backup(backupdb, [](int remaining, int pagecount, int rc) {
+  cout << remaining << "/" << pagecount << " pages left..." << endl;
+});
 ```
 
+## callback hooks
+
 ```cpp
-db.backup(
-  backupdb,
-  [](int pagecount, int remaining, int rc) {
-    cout << pagecount << "/" << remaining << endl;
-    if (rc == SQLITE_OK || rc == SQLITE_BUSY || rc == SQLITE_LOCKED) {
-      // sleep or do nothing.
-    }
-  });
+sqlite3pp::database db(":memory:");
+
+db.set_commit_handler([]{ 
+  cout << "Committed!\n"; 
+  return 0; 
+});
+
+db.set_update_handler([](int opcode, char const* dbname, char const* tablename, long long int rowid) {
+  cout << "Updated " << tablename << " at " << rowid << "\n";
+});
 ```
 
-## callback
+## function (Extensions)
 
 ```cpp
-struct rollback_handler
-{
-  void operator()() {
-    cout << "handle_rollback" << endl;
-  }
-};
-
-sqlite3pp::database db("test.db");
-
-db.set_commit_handler([]{ cout << "handle_commit\n"; return 0; });
-db.set_rollback_handler(rollback_handler());
-```
-
-```cpp
-int handle_authorize(int evcode, char const* p1, char const* p2,
-                     char const* dbname, char const* tvname) {
-  cout << "handle_authorize(" << evcode << ")" << endl;
-  return 0;
-}
-
-db.set_authorize_handler(&handle_authorize);
-```
-
-```cpp
-struct handler
-{
-  handler() : cnt_(0) {}
-
-  void handle_update(int opcode, char const* dbname,
-                     char const* tablename, int64_t rowid) {
-    cout << "handle_update(" << opcode << ", " << dbname << ", "
-         << tablename << ", " << rowid << ") - " << cnt_++ << endl;
-  }
-  int cnt_;
-};
-
-using namespace std::placeholders;
-
-db.set_update_handler(std::bind(&handler::handle_update, &h, _1, _2, _3, _4));
-```
-
-## function
-
-```cpp
-int test0()
-{
-  return 100;
-}
-
-sqlite3pp::database db("test.db");
 sqlite3pp::ext::function func(db);
 
-func.create<int ()>("test0", &test0);
+// Register a C++ lambda as a SQL function
+func.create<int (int, int)>("cpp_add", [](int a, int b) { 
+  return a + b; 
+});
+
+// Support for void return types (returns NULL to SQL)
+func.create<void (string)>("log_text", [](string s) {
+  clog << "SQL Log: " << s << endl;
+});
+
+// Use it in queries
+sqlite3pp::query qry(db, "SELECT cpp_add(1, 2), log_text('hello')");
 ```
 
-```cpp
-void test1(sqlite3pp::ext::context& ctx)
-{
-  ctx.result(200);
-}
-
-void test2(sqlite3pp::ext::context& ctx)
-{
-  string args = ctx.get<string>(0);
-  ctx.result(args);
-}
-
-void test3(sqlite3pp::ext::context& ctx)
-{
-  ctx.result_copy(0);
-}
-
-func.create("test1", &test1);
-func.create("test2", &test2, 1);
-func.create("test3", &test3, 1);
-```
+## aggregate (Extensions)
 
 ```cpp
-func.create<int ()>("test4", []{ return 500; });
-```
-
-```cpp
-string test5(string const& value)
+struct sum_aggr
 {
-  return value;
-}
+  void step(int n) {
+    total_ += n;
+  }
+  int finish() {
+    return total_;
+  }
+  int total_ = 0;
+};
 
-string test6(string const& s1, string const& s2, string const& s3)
-{
-  return s1 + s2 + s3;
-}
-
-func.create<int (int)>("test5", [](int i){ return i + 10000; });
-func.create<string (string, string, string)>("test6", &test6);
-```
-
-```cpp
-sqlite3pp::query qry(
-  db,
-  "SELECT test0(), test1(), test2('x'), test3('y'), test4(), test5(10), "
-  "test6('a', 'b', 'c')");
-```
-
-## aggregate
-
-```cpp
-void step(sqlite3pp::ext::context& c)
-{
-  int* sum = (int*) c.aggregate_data(sizeof(int));
-
-  *sum += c.get<int>(0);
-}
-void finalize(sqlite3pp::ext::context& c)
-{
-  int* sum = (int*) c.aggregate_data(sizeof(int));
-  c.result(*sum);
-}
-
-sqlite3pp::database db("foods.db");
 sqlite3pp::ext::aggregate aggr(db);
+aggr.create<sum_aggr, int>("cpp_sum");
 
-aggr.create("aggr0", &step, &finalize);
-```
-
-```cpp
-struct mycnt
-{
-  void step() {
-    ++n_;
-  }
-  int finish() {
-    return n_;
-  }
-  int n_;
-};
-
-aggr.create<mycnt>("aggr1");
-```
-
-```cpp
-struct strcnt
-{
-  void step(string const& s) {
-    s_ += s;
-  }
-  int finish() {
-    return s_.size();
-  }
-  string s_;
-};
-
-struct plussum
-{
-  void step(int n1, int n2) {
-    n_ += n1 + n2;
-  }
-  int finish() {
-    return n_;
-  }
-  int n_;
-};
-
-aggr.create<strcnt, string>("aggr2");
-aggr.create<plussum, int, int>("aggr3");
-```
-
-```cpp
-sqlite3pp::query qry(
-  db,
-  "SELECT aggr0(id), aggr1(type_id), aggr2(name), aggr3(id, type_id) "
-  "FROM foods");
+sqlite3pp::query qry(db, "SELECT cpp_sum(id) FROM contacts");
 ```
 
 ## loadable extension
@@ -330,23 +195,31 @@ sqlite3pp::query qry(
 #define SQLITE3PP_LOADABLE_EXTENSION
 #include <sqlite3ppext.h>
 
-int sqlite3_extension_init(
+extern "C" int sqlite3_extension_init(
   sqlite3 *pdb,
   char **pzErrMsg,
   const sqlite3_api_routines *pApi) {
   SQLITE_EXTENSION_INIT2(pApi);
-  sqlite3pp:database db(sqlite3pp::ext::borrow(pdb));
-  // pdb is not closed since db just borrows it.
+  
+  // Borrow the raw sqlite3 pointer
+  sqlite3pp::database db(sqlite3pp::ext::borrow(pdb));
+  
+  // Register functions...
+  return SQLITE_OK;
 }
-
 ```
 
+# How to run tests
+
+To run the comprehensive test suite:
+
+```bash
+g++ -std=c++11 -Iheaderonly_src headeronly_src/test_all.cpp -lsqlite3 -o test_all && ./test_all
+```
+
+# Important Note
+Only the files in `headeronly_src` directory are maintained. All other source and test directories (`src`, `boost_src`, `test`) are deprecated and should not be used for new projects.
 
 # See also
 * http://www.sqlite.org/
-* https://code.google.com/p/sqlite3pp/ 
-* https://github.com/iwongu/sqlite3pp/wiki/Using-variadic-templates-with-different-parameter-types
-* https://github.com/iwongu/sqlite3pp/wiki/Using-variadic-templates-with-function-calls-using-tuple
-* [c-of-day-43-sqlite3-c-wrapper-1](http://idea-thinking.blogspot.com/2007/09/c-of-day-43-sqlite3-c-wrapper-1.html) (Korean)
-* [c-of-day-44-sqlite3-c-wrapper-2](http://idea-thinking.blogspot.com/2007/09/c-of-day-44-sqlite3-c-wrapper-2.html) (Korean)
-* [c-of-day-45-sqlite3-c-wrapper-3](http://idea-thinking.blogspot.com/2007/09/c-of-day-45-sqlite3-c-wrapper-3.html) (Korean)
+* https://github.com/iwongu/sqlite3pp/wiki

--- a/headeronly_src/sqlite3pp.h
+++ b/headeronly_src/sqlite3pp.h
@@ -131,6 +131,7 @@ namespace sqlite3pp
 
    private:
     database(sqlite3* pdb) : db_(pdb), borrowing_(true) {}
+    void rebind_handlers();
 
    private:
     sqlite3* db_;
@@ -174,6 +175,7 @@ namespace sqlite3pp
     int bind(char const* name, char const* value, copy_semantic fcopy);
     int bind(char const* name, void const* value, int n, copy_semantic fcopy);
     int bind(char const* name, std::string const& value, copy_semantic fcopy);
+    int bind(char const* name, char16_t const* value, copy_semantic fcopy);
     int bind(char const* name);
     int bind(char const* name, null_type);
 
@@ -220,6 +222,14 @@ namespace sqlite3pp
         return *this;
       }
       bindstream& operator << (std::string const& value) {
+        auto rc = cmd_.bind(idx_, value, copy);
+        if (rc != SQLITE_OK) {
+          throw database_error(cmd_.db_);
+        }
+        ++idx_;
+        return *this;
+      }
+      bindstream& operator << (char16_t const* value) {
         auto rc = cmd_.bind(idx_, value, copy);
         if (rc != SQLITE_OK) {
           throw database_error(cmd_.db_);

--- a/headeronly_src/sqlite3ppext.ipp
+++ b/headeronly_src/sqlite3ppext.ipp
@@ -100,7 +100,8 @@ namespace sqlite3pp
 
     inline std::string context::get(int idx, std::string) const
     {
-      return get(idx, (char const*)0);
+      char const* c = get(idx, (char const*)0);
+      return c ? std::string(c) : std::string();
     }
 
     inline void const* context::get(int idx, void const*) const
@@ -127,7 +128,7 @@ namespace sqlite3pp
 
     inline void context::result(std::string const& value)
     {
-      result(value.c_str(), false);
+      result(value.c_str(), true);
     }
 
     inline void context::result(char const* value, bool fcopy)

--- a/headeronly_src/test_all.cpp
+++ b/headeronly_src/test_all.cpp
@@ -1,0 +1,278 @@
+#include <iostream>
+#include <cassert>
+#include <vector>
+#include <string>
+#include "sqlite3pp.h"
+#include "sqlite3ppext.h"
+
+using namespace std;
+
+void test_database_basic() {
+    cout << "Testing database basic operations..." << endl;
+    sqlite3pp::database db(":memory:");
+    int rc = db.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, val TEXT)");
+    assert(rc == SQLITE_OK);
+
+    rc = db.execute("INSERT INTO test (val) VALUES ('hello')");
+    assert(rc == SQLITE_OK);
+    assert(db.changes() == 1);
+    assert(db.last_insert_rowid() == 1);
+}
+
+void test_database_move() {
+    cout << "Testing database move semantics..." << endl;
+    sqlite3pp::database db1(":memory:");
+    db1.execute("CREATE TABLE test (id INTEGER PRIMARY KEY)");
+    
+    sqlite3pp::database db2(std::move(db1));
+    int rc = db2.execute("INSERT INTO test VALUES (1)");
+    assert(rc == SQLITE_OK);
+
+    sqlite3pp::database db3;
+    db3 = std::move(db2);
+    rc = db3.execute("INSERT INTO test VALUES (2)");
+    assert(rc == SQLITE_OK);
+}
+
+void test_statement_binding() {
+    cout << "Testing statement binding..." << endl;
+    sqlite3pp::database db(":memory:");
+    db.execute("CREATE TABLE test (id INTEGER, f DOUBLE, t TEXT, b BLOB, n TEXT)");
+
+    sqlite3pp::command cmd(db, "INSERT INTO test VALUES (?, ?, ?, ?, ?)");
+    cmd.bind(1, 123);
+    cmd.bind(2, 45.6);
+    cmd.bind(3, "string", sqlite3pp::copy);
+    cmd.bind(4, "blob", 4, sqlite3pp::copy);
+    cmd.bind(5); // null
+    assert(cmd.execute() == SQLITE_OK);
+
+    // Named parameters
+    sqlite3pp::command cmd2(db, "INSERT INTO test VALUES (:id, :f, :t, :b, :n)");
+    cmd2.bind(":id", 456);
+    cmd2.bind(":f", 78.9);
+    cmd2.bind(":t", string("string2"), sqlite3pp::copy);
+    cmd2.bind(":b", "blob2", 5, sqlite3pp::copy);
+    cmd2.bind(":n", sqlite3pp::null_type());
+    assert(cmd2.execute() == SQLITE_OK);
+
+    // Bindstream
+    sqlite3pp::command cmd3(db, "INSERT INTO test VALUES (?, ?, ?, ?, ?)");
+    cmd3.binder() << 789 << 10.11 << "stream" << nullptr << nullptr;
+    assert(cmd3.execute() == SQLITE_OK);
+}
+
+void test_query() {
+    cout << "Testing query operations..." << endl;
+    sqlite3pp::database db(":memory:");
+    db.execute("CREATE TABLE test (id INTEGER, val TEXT)");
+    db.execute("INSERT INTO test VALUES (1, 'one')");
+    db.execute("INSERT INTO test VALUES (2, 'two')");
+
+    sqlite3pp::query qry(db, "SELECT id, val FROM test ORDER BY id");
+    int count = 0;
+    for (auto i = qry.begin(); i != qry.end(); ++i) {
+        auto row = *i;
+        int id;
+        string val;
+        row.getter() >> id >> val;
+        if (count == 0) {
+            assert(id == 1);
+            assert(val == "one");
+        } else {
+            assert(id == 2);
+            assert(val == "two");
+        }
+        count++;
+    }
+    assert(count == 2);
+
+    // get_columns with tuple
+    sqlite3pp::query qry2(db, "SELECT id, val FROM test WHERE id = 1");
+    auto it = qry2.begin();
+    int id;
+    string val;
+    std::tie(id, val) = (*it).get_columns<int, string>(0, 1);
+    assert(id == 1);
+    assert(val == "one");
+}
+
+void test_transaction() {
+    cout << "Testing transactions..." << endl;
+    sqlite3pp::database db(":memory:");
+    db.execute("CREATE TABLE test (id INTEGER)");
+
+    {
+        sqlite3pp::transaction xct(db);
+        db.execute("INSERT INTO test VALUES (1)");
+        // auto rollback
+    }
+
+    {
+        sqlite3pp::query qry(db, "SELECT COUNT(*) FROM test");
+        assert((*qry.begin()).get<int>(0) == 0);
+    }
+
+    {
+        sqlite3pp::transaction xct(db);
+        db.execute("INSERT INTO test VALUES (1)");
+        xct.commit();
+    }
+
+    {
+        sqlite3pp::query qry(db, "SELECT COUNT(*) FROM test");
+        assert((*qry.begin()).get<int>(0) == 1);
+    }
+}
+
+void test_extensions() {
+    cout << "Testing extensions (functions and aggregates)..." << endl;
+    sqlite3pp::database db(":memory:");
+    
+    // Function
+    sqlite3pp::ext::function func(db);
+    func.create<int (int, int)>("myadd", [](int a, int b) { return a + b; });
+    func.create<string (string)>("myecho", [](string s) { return s; });
+    func.create<void (int)>("mynoop", [](int) {});
+
+    sqlite3pp::query qry(db, "SELECT myadd(1, 2), myecho('hello'), mynoop(1)");
+    auto row = *qry.begin();
+    assert(row.get<int>(0) == 3);
+    assert(row.get<string>(1) == "hello");
+    assert(row.column_type(2) == SQLITE_NULL);
+
+    // Aggregate
+    struct sum_aggr {
+        void step(int n) { total += n; }
+        int finish() { return total; }
+        int total = 0;
+    };
+
+    sqlite3pp::ext::aggregate aggr(db);
+    aggr.create<sum_aggr, int>("mysum");
+
+    db.execute("CREATE TABLE nums (n INTEGER)");
+    db.execute("INSERT INTO nums VALUES (10), (20), (30)");
+    
+    sqlite3pp::query qry_aggr(db, "SELECT mysum(n) FROM nums");
+    assert((*qry_aggr.begin()).get<int>(0) == 60);
+}
+
+void test_hooks() {
+    cout << "Testing hooks..." << endl;
+    sqlite3pp::database db(":memory:");
+    db.execute("CREATE TABLE test (id INTEGER)");
+
+    bool updated = false;
+    db.set_update_handler([&](int opcode, char const* dbname, char const* tablename, long long int rowid) {
+        updated = true;
+    });
+
+    db.execute("INSERT INTO test VALUES (1)");
+    assert(updated == true);
+
+    // Test move with hooks
+    updated = false;
+    sqlite3pp::database db2 = std::move(db);
+    db2.execute("INSERT INTO test VALUES (2)");
+    assert(updated == true);
+}
+
+void test_errors() {
+    cout << "Testing error handling..." << endl;
+    sqlite3pp::database db(":memory:");
+    
+    // execute returns error code, doesn't throw
+    int rc = db.execute("SELECT * FROM non_existent");
+    assert(rc != SQLITE_OK);
+
+    // statement/command constructor throws if prepare fails
+    try {
+        sqlite3pp::command cmd(db, "SYNTAX ERROR");
+        assert(false);
+    } catch (sqlite3pp::database_error& e) {
+        cout << "Caught expected database_error: " << e.what() << endl;
+    }
+
+    // Multiple statements with mixed parameters (Issue #62)
+    db.execute("CREATE TABLE issue62 (id INTEGER, val TEXT)");
+    sqlite3pp::command cmd2(db, "INSERT INTO issue62 (id, val) VALUES (?, ?); DELETE FROM issue62 WHERE id = 100");
+    cmd2.bind(1, 100);
+    cmd2.bind(2, "temp", sqlite3pp::copy);
+    int rc2 = cmd2.execute_all();
+    assert(rc2 == SQLITE_OK);
+    
+    sqlite3pp::query qry(db, "SELECT COUNT(*) FROM issue62");
+    assert((*qry.begin()).get<int>(0) == 0); // Inserted then deleted
+}
+
+void test_attach_backup() {
+    cout << "Testing attach and backup..." << endl;
+    sqlite3pp::database db1(":memory:");
+    db1.execute("CREATE TABLE test1 (id INTEGER)");
+    db1.execute("INSERT INTO test1 VALUES (100)");
+
+    sqlite3pp::database db2(":memory:");
+    db2.execute("CREATE TABLE test2 (id INTEGER)");
+    db2.execute("INSERT INTO test2 VALUES (200)");
+
+    // Test Backup
+    int rc = db1.backup(db2);
+    assert(rc == SQLITE_DONE || rc == SQLITE_OK);
+    
+    sqlite3pp::query qry(db2, "SELECT id FROM test1");
+    assert((*qry.begin()).get<int>(0) == 100);
+
+    // Test Attach
+    sqlite3pp::database db3(":memory:");
+    db3.execute("CREATE TABLE test3 (id INTEGER)");
+    db3.execute("INSERT INTO test3 VALUES (300)");
+    
+    // We can't easily attach a ':memory:' db to another, but we can test the call
+    rc = db1.attach(":memory:", "attached_db");
+    assert(rc == SQLITE_OK);
+}
+
+void test_borrow() {
+    cout << "Testing borrow..." << endl;
+    sqlite3* pdb;
+    int rc = sqlite3_open(":memory:", &pdb);
+    assert(rc == SQLITE_OK);
+
+    {
+        sqlite3pp::database db = sqlite3pp::ext::borrow(pdb);
+        db.execute("CREATE TABLE borrowed_test (id INTEGER)");
+        db.execute("INSERT INTO borrowed_test VALUES (1)");
+        // db destructor should not close pdb
+    }
+
+    sqlite3_stmt* stmt;
+    rc = sqlite3_prepare_v2(pdb, "SELECT id FROM borrowed_test", -1, &stmt, nullptr);
+    assert(rc == SQLITE_OK);
+    rc = sqlite3_step(stmt);
+    assert(rc == SQLITE_ROW);
+    assert(sqlite3_column_int(stmt, 0) == 1);
+
+    sqlite3_finalize(stmt);
+    sqlite3_close(pdb);
+}
+
+int main() {
+    try {
+        test_database_basic();
+        test_database_move();
+        test_statement_binding();
+        test_query();
+        test_transaction();
+        test_extensions();
+        test_hooks();
+        test_errors();
+        test_attach_backup();
+        test_borrow();
+        cout << "All tests passed successfully!" << endl;
+    } catch (exception& e) {
+        cerr << "Test failed with exception: " << e.what() << endl;
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
This PR introduces several improvements and fixes to the header-only implementation:

- **Bug Fixes:**
  - Fixed SIGSEGV in `command::execute_all()` with trailing whitespace (#78).
  - Fixed memory corruption in string extension results by using `SQLITE_TRANSIENT` (#81).
  - Fixed `execute_all()` to handle mixed parameterized and non-parameterized statements (#62).
  - Fixed potential connection leak and hook corruption during database move operations.
  - Fixed potential crash when retrieving NULL values as `std::string`.

- **New Features:**
  - Added support for `void` return types in SQL extension functions and aggregates.
  - Added full `char16_t` (UTF-16) support for named parameters and stream binding.

- **Improvements:**
  - Added a comprehensive, self-contained test suite in `headeronly_src/test_all.cpp`.
  - Modernized the codebase using C++11 features (`nullptr`, move semantics).
  - Updated `README.md` with modern examples and project status clarification.
  - Replaced `sqlite3_close` with `sqlite3_close_v2` for safer teardown.