### PR TITLE
Linker error

### DIFF
--- a/headeronly_src/sqlite3ppext.h
+++ b/headeronly_src/sqlite3ppext.h
@@ -76,7 +76,7 @@ namespace sqlite3pp
 
   namespace ext
   {
-    database borrow(sqlite3* pdb) {
+    inline database borrow(sqlite3* pdb) {
       return database(pdb);
     }
 


### PR DESCRIPTION
Thank you very much for all of your work.

Description:
Avoid linker error by inlining the borrow function.