### PR TITLE
Narrowing conversion warning

### DIFF
--- a/headeronly_src/sqlite3pp.ipp
+++ b/headeronly_src/sqlite3pp.ipp
@@ -308,7 +308,7 @@ namespace sqlite3pp
 
   inline int statement::prepare_impl(char const* stmt)
   {
-    return sqlite3_prepare_v2(db_.db_, stmt, std::strlen(stmt), &stmt_, &tail_);
+    return sqlite3_prepare_v2(db_.db_, stmt, static_cast<int>(std::strlen(stmt)), &stmt_, &tail_);
   }
 
   inline int statement::finish()
@@ -360,12 +360,12 @@ namespace sqlite3pp
 
   inline int statement::bind(int idx, char const* value, copy_semantic fcopy)
   {
-    return sqlite3_bind_text(stmt_, idx, value, std::strlen(value), fcopy == copy ? SQLITE_TRANSIENT : SQLITE_STATIC );
+    return sqlite3_bind_text(stmt_, idx, value, static_cast<int>(std::strlen(value)), fcopy == copy ? SQLITE_TRANSIENT : SQLITE_STATIC );
   }
 
   inline int statement::bind(int idx, char16_t const* value, copy_semantic fcopy)
   {
-    return sqlite3_bind_text16(stmt_, idx, value, std::char_traits<char16_t>::length(value) * sizeof(char16_t), fcopy == copy ? SQLITE_TRANSIENT : SQLITE_STATIC );
+    return sqlite3_bind_text16(stmt_, idx, value, static_cast<int>(std::char_traits<char16_t>::length(value) * sizeof(char16_t)), fcopy == copy ? SQLITE_TRANSIENT : SQLITE_STATIC );
   }
 
   inline int statement::bind(int idx, void const* value, int n, copy_semantic fcopy)
@@ -375,7 +375,7 @@ namespace sqlite3pp
 
   inline int statement::bind(int idx, std::string const& value, copy_semantic fcopy)
   {
-    return sqlite3_bind_text(stmt_, idx, value.c_str(), value.size(), fcopy == copy ? SQLITE_TRANSIENT : SQLITE_STATIC );
+    return sqlite3_bind_text(stmt_, idx, value.c_str(), static_cast<int>(value.size()), fcopy == copy ? SQLITE_TRANSIENT : SQLITE_STATIC );
   }
 
   inline int statement::bind(int idx)

--- a/headeronly_src/sqlite3ppext.ipp
+++ b/headeronly_src/sqlite3ppext.ipp
@@ -133,7 +133,7 @@ namespace sqlite3pp
 
     inline void context::result(char const* value, bool fcopy)
     {
-      sqlite3_result_text(ctx_, value, std::strlen(value), fcopy ? SQLITE_TRANSIENT : SQLITE_STATIC);
+      sqlite3_result_text(ctx_, value, static_cast<int>(std::strlen(value)), fcopy ? SQLITE_TRANSIENT : SQLITE_STATIC);
     }
 
     inline void context::result(void const* value, int n, bool fcopy)
@@ -158,7 +158,7 @@ namespace sqlite3pp
 
     inline void context::result_error(char const* msg)
     {
-      sqlite3_result_error(ctx_, msg, std::strlen(msg));
+      sqlite3_result_error(ctx_, msg, static_cast<int>(std::strlen(msg)));
     }
 
     inline void* context::aggregate_data(int size)


### PR DESCRIPTION
Thank you very much for all of your work.

Description:
Avoid the warning: narrowing conversion
Implicit conversion from std::size_t to int